### PR TITLE
Use api keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,8 @@ We have each celery worker running as a container, this is because of how WebGra
 5. Reading all docker logs
     -  `docker compose -f docker-compose.yml -f docker-compose.prod.yml logs --follow`
     - See docs on docker compose logs [here](https://docs.docker.com/engine/reference/commandline/compose_logs/)
+6. Creating an API Key.
+    - log in as a superuser and create an API key using the admin dashboard.
 
 ### Tutorial on how to use Django and Celery.
 - [Real python tutorial](https://realpython.com/asynchronous-tasks-with-django-and-celery/#handle-workloads-asynchronously-with-celery)
-

--- a/grab_requests/urls.py
+++ b/grab_requests/urls.py
@@ -14,11 +14,13 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.contrib import admin
 from django.urls import path
-from grab_requests.views import (
-    GrabRequestListView, GrabRequestDetailView, GrabRequestBulkCreateView, GrabSettingListView, GrabSettingDetailView, UpdateSitePack
-)
 
+from grab_requests.views import (GrabRequestBulkCreateView,
+                                 GrabRequestDetailView, GrabRequestListView,
+                                 GrabSettingDetailView, GrabSettingListView,
+                                 UpdateSitePack)
 
 urlpatterns = [
     path('', GrabRequestListView.as_view(), name='home'),
@@ -27,4 +29,5 @@ urlpatterns = [
     path('settings', GrabSettingListView.as_view(), name='grab_settings'),
     path('settings/<int:pk>/', GrabSettingDetailView.as_view(), name='grab_settings_update'),
     path('update-site-pack', UpdateSitePack.as_view(), name='update_site_pack'),
+    path('admin/', admin.site.urls),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ Django==4.2.1
 django-filter==23.2
 django-rest-swagger==2.2.0
 djangorestframework==3.14.0
+djangorestframework-api-key==2.3.0
 drf-spectacular==0.26.2
 func-timeout==4.3.5
 idna==3.4

--- a/web_grab/settings.py
+++ b/web_grab/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'rest_framework',
+    'rest_framework_api_key',
     'drf_spectacular',
     # Custom apps
     'grab_requests',
@@ -138,6 +139,9 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 50,
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework_api_key.permissions.HasAPIKey',
+    ]
 }
 
 CELERY_BROKER_URL = os.environ.get('CELERY_BROKER_URL')


### PR DESCRIPTION
Need to authenticate API requests that are coming in.
To do that we need each request to have an API Key attached to the request being made.